### PR TITLE
Add support for internationalization (i18n) in Odoo

### DIFF
--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -9,7 +9,7 @@ import type {
 import { NodeApiError, randomInt } from 'n8n-workflow';
 
 const serviceJSONRPC = 'object';
-const methodJSONRPC = 'execute';
+const methodJSONRPC = 'execute_kw';
 
 export const mapOperationToJSONRPC = {
 	create: 'create',
@@ -147,7 +147,7 @@ export async function odooGetModelFields(
 			method: 'call',
 			params: {
 				service: serviceJSONRPC,
-				method: methodJSONRPC,
+				method: 'execute',
 				args: [
 					db,
 					userID,
@@ -177,6 +177,7 @@ export async function odooCreate(
 	operation: OdooCRUD,
 	url: string,
 	newItem: IDataObject,
+	context?: IDataObject,
 ) {
 	try {
 		const body = {
@@ -191,7 +192,8 @@ export async function odooCreate(
 					password,
 					mapOdooResources[resource] || resource,
 					mapOperationToJSONRPC[operation],
-					newItem || {},
+					[newItem || {}],
+					{ context: context || {} },
 				],
 			},
 			id: randomInt(100),
@@ -214,6 +216,7 @@ export async function odooGet(
 	url: string,
 	itemsID: string,
 	fieldsToReturn?: IDataObject[],
+	context?: IDataObject,
 ) {
 	try {
 		if (!/^\d+$/.test(itemsID) || !parseInt(itemsID, 10)) {
@@ -235,7 +238,10 @@ export async function odooGet(
 					mapOdooResources[resource] || resource,
 					mapOperationToJSONRPC[operation],
 					itemsID ? [+itemsID] : [],
-					fieldsToReturn || [],
+					{
+						fields: fieldsToReturn || [],
+						context: context || {},
+					}
 				],
 			},
 			id: randomInt(100),
@@ -259,6 +265,7 @@ export async function odooGetAll(
 	filters?: IOdooFilterOperations,
 	fieldsToReturn?: IDataObject[],
 	limit = 0,
+	context?: IDataObject,
 ) {
 	try {
 		const body = {
@@ -274,9 +281,12 @@ export async function odooGetAll(
 					mapOdooResources[resource] || resource,
 					mapOperationToJSONRPC[operation],
 					(filters && processFilters(filters)) || [],
-					fieldsToReturn || [],
-					0, // offset
-					limit,
+					{
+						fields: fieldsToReturn || [],
+						offset: 0,
+						limit: limit,
+						context: context || {},
+					}
 				],
 			},
 			id: randomInt(100),
@@ -299,6 +309,7 @@ export async function odooUpdate(
 	url: string,
 	itemsID: string,
 	fieldsToUpdate: IDataObject,
+	context?: IDataObject,
 ) {
 	try {
 		if (!Object.keys(fieldsToUpdate).length) {
@@ -325,8 +336,8 @@ export async function odooUpdate(
 					password,
 					mapOdooResources[resource] || resource,
 					mapOperationToJSONRPC[operation],
-					itemsID ? [+itemsID] : [],
-					fieldsToUpdate,
+					[itemsID ? [+itemsID] : [], fieldsToUpdate],
+					{ context: context || {} },
 				],
 			},
 			id: randomInt(100),
@@ -348,6 +359,7 @@ export async function odooDelete(
 	operation: OdooCRUD,
 	url: string,
 	itemsID: string,
+	context?: IDataObject,
 ) {
 	if (!/^\d+$/.test(itemsID) || !parseInt(itemsID, 10)) {
 		throw new NodeApiError(this.getNode(), {
@@ -369,6 +381,7 @@ export async function odooDelete(
 					mapOdooResources[resource] || resource,
 					mapOperationToJSONRPC[operation],
 					itemsID ? [+itemsID] : [],
+					{ context: context || {} }
 				],
 			},
 			id: randomInt(100),

--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -381,7 +381,7 @@ export async function odooDelete(
 					mapOdooResources[resource] || resource,
 					mapOperationToJSONRPC[operation],
 					itemsID ? [+itemsID] : [],
-					{ context: context || {} }
+					{ context: context || {} },
 				],
 			},
 			id: randomInt(100),

--- a/packages/nodes-base/nodes/Odoo/descriptions/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/ContactDescription.ts
@@ -270,7 +270,7 @@ export const contactDescription: INodeProperties[] = [
 		name: 'options',
 		type: 'collection',
 		default: {},
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				operation: ['getAll', 'get'],

--- a/packages/nodes-base/nodes/Odoo/descriptions/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/ContactDescription.ts
@@ -186,6 +186,31 @@ export const contactDescription: INodeProperties[] = [
 			},
 		],
 	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['create'],
+				resource: ['contact'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
+		],
+	},
 
 	/* -------------------------------------------------------------------------- */
 	/*                                contact:get                                 */
@@ -262,6 +287,16 @@ export const contactDescription: INodeProperties[] = [
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getModelFields',
+				},
+			},
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
 				},
 			},
 		],
@@ -408,6 +443,60 @@ export const contactDescription: INodeProperties[] = [
 				name: 'website',
 				type: 'string',
 				default: '',
+			},
+		],
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['contact'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
+		],
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                                contact:delete                              */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['delete'],
+				resource: ['contact'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
@@ -130,7 +130,6 @@ export const customResourceDescription: INodeProperties[] = [
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getSupportedLanguages',
-					loadOptionsDependsOn: ['customResource'],
 				},
 			},
 		],
@@ -220,7 +219,6 @@ export const customResourceDescription: INodeProperties[] = [
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getSupportedLanguages',
-					loadOptionsDependsOn: ['customResource'],
 				},
 			},
 		],
@@ -400,7 +398,6 @@ export const customResourceDescription: INodeProperties[] = [
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getSupportedLanguages',
-					loadOptionsDependsOn: ['customResource'],
 				},
 			},
 		],

--- a/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
@@ -109,6 +109,32 @@ export const customResourceDescription: INodeProperties[] = [
 			},
 		],
 	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['create'],
+				resource: ['custom'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+					loadOptionsDependsOn: ['customResource'],
+				},
+			},
+		],
+	},
 
 	/* -------------------------------------------------------------------------- */
 	/*                                custom:get                                  */
@@ -166,7 +192,7 @@ export const customResourceDescription: INodeProperties[] = [
 		name: 'options',
 		type: 'collection',
 		default: {},
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				operation: ['getAll', 'get'],
@@ -183,6 +209,17 @@ export const customResourceDescription: INodeProperties[] = [
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getModelFields',
+					loadOptionsDependsOn: ['customResource'],
+				},
+			},
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
 					loadOptionsDependsOn: ['customResource'],
 				},
 			},
@@ -282,6 +319,7 @@ export const customResourceDescription: INodeProperties[] = [
 			},
 		],
 	},
+
 	/* -------------------------------------------------------------------------- */
 	/*                                custom:update                               */
 	/* -------------------------------------------------------------------------- */
@@ -338,6 +376,61 @@ export const customResourceDescription: INodeProperties[] = [
 						default: '',
 					},
 				],
+			},
+		],
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['custom'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+					loadOptionsDependsOn: ['customResource'],
+				},
+			},
+		],
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                                custom:delete                               */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['delete'],
+				resource: ['custom'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Odoo/descriptions/NoteDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/NoteDescription.ts
@@ -172,7 +172,7 @@ export const noteDescription: INodeProperties[] = [
 		name: 'options',
 		type: 'collection',
 		default: {},
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				operation: ['getAll', 'get'],

--- a/packages/nodes-base/nodes/Odoo/descriptions/NoteDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/NoteDescription.ts
@@ -89,6 +89,31 @@ export const noteDescription: INodeProperties[] = [
 	// 		},
 	// 	],
 	// },
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['create'],
+				resource: ['note'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
+		],
+	},
 
 	/* -------------------------------------------------------------------------- */
 	/*                                note:get                                    */
@@ -166,8 +191,19 @@ export const noteDescription: INodeProperties[] = [
 					loadOptionsMethod: 'getModelFields',
 				},
 			},
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
 		],
 	},
+
 	/* -------------------------------------------------------------------------- */
 	/*                                note:update                                 */
 	/* -------------------------------------------------------------------------- */
@@ -228,4 +264,58 @@ export const noteDescription: INodeProperties[] = [
 	// 		},
 	// 	],
 	// },
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['note'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
+		],
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                                note:delete                                 */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['delete'],
+				resource: ['note'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
+		],
+	},
 ];

--- a/packages/nodes-base/nodes/Odoo/descriptions/OpportunityDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/OpportunityDescription.ts
@@ -140,6 +140,31 @@ export const opportunityDescription: INodeProperties[] = [
 			},
 		],
 	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['create'],
+				resource: ['opportunity'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
+		],
+	},
 
 	/* -------------------------------------------------------------------------- */
 	/*                                opportunity:get                             */
@@ -217,8 +242,19 @@ export const opportunityDescription: INodeProperties[] = [
 					loadOptionsMethod: 'getModelFields',
 				},
 			},
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
 		],
 	},
+
 	/* -------------------------------------------------------------------------- */
 	/*                                opportunity:update                          */
 	/* -------------------------------------------------------------------------- */
@@ -312,6 +348,60 @@ export const opportunityDescription: INodeProperties[] = [
 				typeOptions: {
 					maxValue: 100,
 					minValue: 0,
+				},
+			},
+		],
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['opportunity'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
+				},
+			},
+		],
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                                opportunity:delete                          */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				operation: ['delete'],
+				resource: ['opportunity'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Language',
+				name: 'language',
+				type: 'options',
+				description: 'Choose from the list',
+				default: '',
+				typeOptions: {
+					loadOptionsMethod: 'getSupportedLanguages',
 				},
 			},
 		],

--- a/packages/nodes-base/nodes/Odoo/descriptions/OpportunityDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/OpportunityDescription.ts
@@ -223,7 +223,7 @@ export const opportunityDescription: INodeProperties[] = [
 		name: 'options',
 		type: 'collection',
 		default: {},
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				operation: ['getAll', 'get'],


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

As a Brazilian user, I want to pass the language code "pt_BR" in Odoo requests so that responses are returned in Portuguese. This pull request introduces support for selecting a language in the Odoo nodes, allowing users to specify their preferred language for localized responses.