### PR TITLE
Add support for IN and NOT IN clauses in PostgreSQL nodes

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
@@ -251,6 +251,14 @@ export const whereFixedCollection: INodeProperties = {
 							value: '!=',
 						},
 						{
+							name: 'In',
+							value: 'IN',
+						},
+						{
+							name: 'Not In',
+							value: 'NOT IN',
+						},
+						{
 							name: 'Like',
 							value: 'LIKE',
 						},

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -4,11 +4,15 @@ import type pg from 'pg-promise/typescript/pg-subset';
 
 export type QueryMode = 'single' | 'transaction' | 'independently';
 
-export type QueryValue = string | number | IDataObject | string[];
+export type QueryValue = string | number | IDataObject | string[] | number[];
 export type QueryValues = QueryValue[];
 export type QueryWithValues = { query: string; values?: QueryValues };
 
-export type WhereClause = { column: string; condition: string; value: string | number };
+export type WhereClause = {
+	column: string;
+	condition: string;
+	value: string | number | string[] | number[];
+};
 export type SortRule = { column: string; direction: string };
 export type ColumnInfo = {
 	column_name: string;


### PR DESCRIPTION
## Summary

Add support for `IN` and `NOT IN` clauses in PostgreSQL nodes.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
